### PR TITLE
Add `Pool::get_owned`

### DIFF
--- a/bb8/src/api.rs
+++ b/bb8/src/api.rs
@@ -55,14 +55,10 @@ impl<M: ManageConnection> Pool<M> {
         self.inner.get().await
     }
 
-    /// Retrieves an owned connection from the pool.
+    /// Retrieves an owned connection from the pool
     ///
-    /// [`Pool::get`] should be preferred for situations where an owned
-    /// connection type isn't necessary.
-    ///
-    /// This contains a reference to the pool and will prevent the it from being
-    /// dropped, while an owned connection is alive. So if an owned connection
-    /// is leaked, the pool will never be shutdown.
+    /// Using an owning `PooledConnection` makes it easier to leak the connection pool. Therefore, [`Pool::get`] 
+    /// (which stores a lifetime-bound reference to the pool) should be preferred whenever possible.
     pub async fn get_owned(&self) -> Result<PooledConnection<'static, M>, RunError<M::Error>> {
         self.inner.get_owned().await
     }

--- a/bb8/src/api.rs
+++ b/bb8/src/api.rs
@@ -365,14 +365,7 @@ where
     M: ManageConnection,
 {
     fn drop(&mut self) {
-        match &self.pool {
-            Cow::Borrowed(pool) => {
-                pool.put_back(self.conn.take());
-            }
-            Cow::Owned(pool) => {
-                pool.put_back(self.conn.take());
-            }
-        }
+        self.pool.as_ref().put_back(self.conn.take())
     }
 }
 

--- a/bb8/src/inner.rs
+++ b/bb8/src/inner.rs
@@ -83,14 +83,14 @@ where
     }
 
     pub(crate) async fn get(&self) -> Result<PooledConnection<'_, M>, RunError<M::Error>> {
-        self.make_pool(|this, conn| PooledConnection::new(this, conn))
+        self.make_pooled(|this, conn| PooledConnection::new(this, conn))
             .await
     }
 
     pub(crate) async fn get_owned(
         &self,
     ) -> Result<PooledConnection<'static, M>, RunError<M::Error>> {
-        self.make_pool(|this, conn| {
+        self.make_pooled(|this, conn| {
             let pool = PoolInner {
                 inner: Arc::clone(&this.inner),
             };
@@ -99,7 +99,7 @@ where
         .await
     }
 
-    pub(crate) async fn make_pool<'a, 'b, F>(
+    pub(crate) async fn make_pooled<'a, 'b, F>(
         &'a self,
         make_pool: F,
     ) -> Result<PooledConnection<'b, M>, RunError<M::Error>>

--- a/bb8/src/inner.rs
+++ b/bb8/src/inner.rs
@@ -83,13 +83,36 @@ where
     }
 
     pub(crate) async fn get(&self) -> Result<PooledConnection<'_, M>, RunError<M::Error>> {
+        self.get_with(|this, conn| PooledConnection::new(this, conn))
+            .await
+    }
+
+    pub(crate) async fn get_owned(
+        &self,
+    ) -> Result<PooledConnection<'static, M>, RunError<M::Error>> {
+        self.get_with(|this, conn| {
+            let pool = PoolInner {
+                inner: Arc::clone(&this.inner),
+            };
+            PooledConnection::new_owned(pool, conn)
+        })
+        .await
+    }
+
+    pub(crate) async fn get_with<'a, 'b, F>(
+        &'a self,
+        make_pool: F,
+    ) -> Result<PooledConnection<'b, M>, RunError<M::Error>>
+    where
+        F: Fn(&'a Self, Conn<M::Connection>) -> PooledConnection<'b, M>,
+    {
         loop {
             let mut conn = {
                 let mut locked = self.inner.internals.lock();
                 match locked.pop(&self.inner.statics) {
                     Some((conn, approvals)) => {
                         self.spawn_replenishing_approvals(approvals);
-                        PooledConnection::new(self, conn)
+                        make_pool(self, conn)
                     }
                     None => break,
                 }
@@ -117,7 +140,7 @@ where
         };
 
         match timeout(self.inner.statics.connection_timeout, rx).await {
-            Ok(Ok(mut guard)) => Ok(PooledConnection::new(self, guard.extract())),
+            Ok(Ok(mut guard)) => Ok(make_pool(self, guard.extract())),
             _ => Err(RunError::TimedOut),
         }
     }

--- a/bb8/src/inner.rs
+++ b/bb8/src/inner.rs
@@ -83,14 +83,14 @@ where
     }
 
     pub(crate) async fn get(&self) -> Result<PooledConnection<'_, M>, RunError<M::Error>> {
-        self.get_with(|this, conn| PooledConnection::new(this, conn))
+        self.make_pool(|this, conn| PooledConnection::new(this, conn))
             .await
     }
 
     pub(crate) async fn get_owned(
         &self,
     ) -> Result<PooledConnection<'static, M>, RunError<M::Error>> {
-        self.get_with(|this, conn| {
+        self.make_pool(|this, conn| {
             let pool = PoolInner {
                 inner: Arc::clone(&this.inner),
             };
@@ -99,7 +99,7 @@ where
         .await
     }
 
-    pub(crate) async fn get_with<'a, 'b, F>(
+    pub(crate) async fn make_pool<'a, 'b, F>(
         &'a self,
         make_pool: F,
     ) -> Result<PooledConnection<'b, M>, RunError<M::Error>>


### PR DESCRIPTION
Fixes https://github.com/djc/bb8/issues/72

This adds `Pool::get_owned` which returns `Result<PooledConnection<'static, M>, _>`. The `'static` means this pool is "detached" from the lifetime of the pool itself and can thus be used where the lifetime the pool gets in the way.

Considerations I made:

- Introduce a new connection type like `OwnedPooledConnection<M>` (similar to [`tokio::sync::OwnedSemaphorePermit`](https://docs.rs/tokio/1.8.1/tokio/sync/struct.OwnedSemaphorePermit.html)). However I imagine having two types of connections will be when you have to abstract over `OwnedPooledConnection` and `PooledConnection`.
- Make `PooledConnection` keep either a `std::sync::Weak<PoolInner<M>>` or a `&'a PoolInner<M>`. However that would require calling `Arc::upgrade` for most operations and how would one handle the case where that returns `None`? I guess pancking is the only option but I don't think thats ideal. I think storing an owned `PoolInner<M>` is nicer and leads to fewer surprises, though it does make it possible to leak the pool.

I have verified that this works for my use-case.