### PR TITLE
Implement `multiplexed-connections` feature

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -6,10 +6,15 @@ license = "MIT"
 repository = "https://github.com/djc/bb8"
 edition = "2018"
 
+[features]
+multiplexed-connections = []
+
 [dependencies]
 async-trait = "0.1"
 bb8 = { version = "0.7", path = "../bb8" }
-redis = { version = "0.21.1", default-features = false, features = ["tokio-comp"] }
+redis = { version = "0.21.1", default-features = false, features = [
+    "tokio-comp",
+] }
 
 [dev-dependencies]
 futures-util = "0.3.15"


### PR DESCRIPTION
Implement multiplexed connections in order to implement a workaround against issue #95.
This workaround was mentioned by the author of the redis-rs library: https://github.com/mitsuhiko/redis-rs/issues/325#issuecomment-846007813

Based on my experience of the last few weeks, the issue didn't occur anymore after using `MultiplexedConnection` instead of `Connection`. 