### PR TITLE
UUID 1 for bb8

### DIFF
--- a/postgres/Cargo.toml
+++ b/postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bb8-postgres"
-version = "0.8.0"
+version = "0.8.1"
 description = "Full-featured async (tokio-based) postgres connection pool (like r2d2)"
 license = "MIT"
 repository = "https://github.com/djc/bb8"

--- a/postgres/Cargo.toml
+++ b/postgres/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 "with-geo-types-0_6" = ["tokio-postgres/with-geo-types-0_6"]
 "with-serde_json-1" = ["tokio-postgres/with-serde_json-1"]
 "with-uuid-0_8" = ["tokio-postgres/with-uuid-0_8"]
+"with-uuid-1" = ["tokio-postgres/with-uuid-1"]
 "with-time-0_2" = ["tokio-postgres/with-time-0_2"]
 "with-time-0_3" = ["tokio-postgres/with-time-0_3"]
 


### PR DESCRIPTION
This PR is a response to https://github.com/djc/bb8/issues/127.

I did two things:

1. added `with-uuid-1` flag to `bb8-postgres`
2. bump the version of `bb8-postgres`
