### PR TITLE
Fix readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,20 +37,22 @@ Backend | Adapter Crate
 Using an imaginary "foodb" database.
 
 ```rust
-fn main() {
+#[tokio::main]
+async fn main() {
     let manager = bb8_foodb::FooConnectionManager::new("localhost:1234");
     let pool = bb8::Pool::builder()
         .max_size(15)
         .build(manager)
+        .await
         .unwrap();
 
     for _ in 0..20 {
         let pool = pool.clone();
-        tokio::spawn(move || {
+        tokio::spawn(async move {
             let conn = pool.get().await.unwrap();
             // use the connection
             // it will be returned to the pool when it falls out of scope.
-        })
+        });
     }
 }
 ```


### PR DESCRIPTION
This alllows to simply replace `bb8_foodb::FooConnectionManager::new("localhost:1234")` with `bb8_redis::RedisConnectionManager::new("redis://localhost:1234").unwrap()` as an example and code will compile!