### PR TITLE
feature: add bb8-redis-cluster

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,5 @@ members = [
     "bb8",
     "postgres",
     "redis",
+    "redis-cluster",
 ]

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Backend | Adapter Crate
 ------- | -------------
 [tokio-postgres](https://github.com/sfackler/rust-postgres) | [bb8-postgres](https://crates.io/crates/bb8-postgres) (in-tree)
 [redis](https://github.com/mitsuhiko/redis-rs) | [bb8-redis](https://crates.io/crates/bb8-redis) (in-tree)
+[redis-cluster](https://github.com/redis-rs/redis-cluster-async) | [bb8-redis-cluster](https://crates.io/crates/bb8-redis-cluster) (in-tree)
 [rsmq](https://github.com/smrchy/rsmq) | [rsmq_async](https://crates.io/crates/rsmq_async)
 [bolt-client](https://crates.io/crates/bolt-client) | [bb8-bolt](https://crates.io/crates/bb8-bolt)
 [diesel](https://crates.io/crates/diesel) | [bb8-diesel](https://crates.io/crates/bb8-diesel)

--- a/redis-cluster/Cargo.toml
+++ b/redis-cluster/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "bb8-redis-cluster"
+version = "0.12.0"
+description = "Full-featured async (tokio-based) redis cluster connection pool (like r2d2)"
+license = "MIT"
+repository = "https://github.com/djc/bb8"
+edition = "2021"
+rust-version = "1.56"
+
+[dependencies]
+async-trait = "0.1"
+bb8 = { version = "0.8", path = "../bb8" }
+redis = { version = "0.21.6", default-features = false, features = ["tokio-comp"] }
+redis_cluster_async="0.7.0"
+
+[dev-dependencies]
+futures-util = "0.3.15"
+tokio = { version = "1.0.0", features = ["macros", "rt-multi-thread"] }

--- a/redis-cluster/src/lib.rs
+++ b/redis-cluster/src/lib.rs
@@ -1,0 +1,92 @@
+//! Redis Cluster support for the `bb8` connection pool.
+//!
+//! # Example
+//!
+//! ```
+//! use futures_util::future::join_all;
+//! use bb8_redis_cluster::{
+//!     bb8,
+//!     redis_cluster_async::redis::{cmd, AsyncCommands},
+//!     RedisConnectionManager
+//! };
+//!
+//! #[tokio::main]
+//! async fn main() {
+//!     let manager = RedisConnectionManager::new(vec!["redis://localhost"]).unwrap();
+//!     let pool = bb8::Pool::builder().build(manager).await.unwrap();
+//!
+//!     let mut handles = vec![];
+//!
+//!     for _i in 0..10 {
+//!         let pool = pool.clone();
+//!
+//!         handles.push(tokio::spawn(async move {
+//!             let mut conn = pool.get().await.unwrap();
+//!
+//!             let reply: String = cmd("PING").query_async(&mut *conn).await.unwrap();
+//!
+//!             assert_eq!("PONG", reply);
+//!         }));
+//!     }
+//!
+//!     join_all(handles).await;
+//! }
+//! ```
+#![allow(clippy::needless_doctest_main)]
+#![deny(missing_docs, missing_debug_implementations)]
+
+pub use bb8;
+pub use redis_cluster_async;
+
+use async_trait::async_trait;
+use redis_cluster_async::{
+    redis::{ErrorKind, IntoConnectionInfo, RedisError},
+    Client, Connection,
+};
+
+/// A `bb8::ManageConnection` for `redis_cluster_async::Client::get_connection`.
+#[derive(Clone)]
+pub struct RedisConnectionManager {
+    client: Client,
+}
+
+// Because redis_cluster_async::Client does not support Debug derive.
+impl std::fmt::Debug for RedisConnectionManager {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RedisConnectionManager")
+            .field("client", &format!("pointer({:p})", &self.client))
+            .finish()
+    }
+}
+
+impl RedisConnectionManager {
+    /// Create a new `RedisConnectionManager`.
+    /// See `redis_cluster_async::Client::open` for a description of the parameter types.
+    pub fn new<T: IntoConnectionInfo>(infos: Vec<T>) -> Result<RedisConnectionManager, RedisError> {
+        Ok(RedisConnectionManager {
+            client: Client::open(infos.into_iter().collect())?,
+        })
+    }
+}
+
+#[async_trait]
+impl bb8::ManageConnection for RedisConnectionManager {
+    type Connection = Connection;
+    type Error = RedisError;
+
+    async fn connect(&self) -> Result<Self::Connection, Self::Error> {
+        self.client.get_connection().await
+    }
+
+    async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
+        let pong: String = redis::cmd("PING").query_async(conn).await?;
+        match pong.as_str() {
+            "PONG" => Ok(()),
+            _ => Err((ErrorKind::ResponseError, "ping request").into()),
+        }
+    }
+
+    fn has_broken(&self, _: &mut Self::Connection) -> bool {
+        false
+    }
+}


### PR DESCRIPTION
- add bb8-redis-cluster implement based on bb8-redis implement
- it use redis 0.21.6 not 0.22.0 (latest) because redis_cluster_async 0.7.0 (latest) do not support redis 0.22.0 (latest) yet.