### PR TITLE
Add option to retry connection creation, on by default

### DIFF
--- a/bb8/src/api.rs
+++ b/bb8/src/api.rs
@@ -228,7 +228,7 @@ impl<M: ManageConnection> Builder<M> {
         self
     }
 
-    /// Instructs the pool to automatically retry connection creation if it fails.
+    /// Instructs the pool to automatically retry connection creation if it fails, until the `connection_timeout` has expired.
     ///
     /// Useful for transient connectivity errors like temporary DNS resolution failure
     /// or intermittent network failures. Some applications however are smart enough to

--- a/bb8/src/inner.rs
+++ b/bb8/src/inner.rs
@@ -212,7 +212,7 @@ where
                     return Ok(());
                 }
                 Err(e) => {
-                    if Instant::now() - start > self.inner.statics.connection_timeout {
+                    if !self.inner.statics.retry_connection || Instant::now() - start > self.inner.statics.connection_timeout {
                         let mut locked = shared.internals.lock();
                         locked.connect_failed(approval);
                         return Err(e);

--- a/bb8/src/inner.rs
+++ b/bb8/src/inner.rs
@@ -212,7 +212,9 @@ where
                     return Ok(());
                 }
                 Err(e) => {
-                    if !self.inner.statics.retry_connection || Instant::now() - start > self.inner.statics.connection_timeout {
+                    if !self.inner.statics.retry_connection
+                        || Instant::now() - start > self.inner.statics.connection_timeout
+                    {
                         let mut locked = shared.internals.lock();
                         locked.connect_failed(approval);
                         return Err(e);


### PR DESCRIPTION
Fix for #102

Overall I agree with the point that connection retries are good and transient errors are common. However, sometimes the application knows better. E.g. we use bb8 in https://github.com/levkk/pgcat and during database restarts, we don't want bb8 to retry because we know the database is down (just for a few seconds), and we have logic to handle and back-off in our code. In our situation, we have thousands of clients creating a thundering herd of retries.

This PR makes the retries optional, enabled by default to preserve existing behavior.