### PR TITLE
bb8: Make parking_lot an optional feature enabled by default

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.58.0
+          toolchain: 1.60.0
           override: true
       - uses: actions-rs/cargo@v1
         with:

--- a/bb8/Cargo.toml
+++ b/bb8/Cargo.toml
@@ -13,8 +13,12 @@ rust-version = "1.60"
 async-trait = "0.1"
 futures-channel = "0.3.2"
 futures-util = { version = "0.3.2", default-features = false, features = ["channel"] }
-parking_lot = "0.12"
-tokio = { version = "1.0", features = ["rt", "time", "parking_lot"] }
+parking_lot = { version = "0.12", optional = true }
+tokio = { version = "1.0", features = ["rt", "time"] }
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros"] }
+
+[features]
+parking_lot = ["dep:parking_lot", "tokio/parking_lot"]
+default = ["parking_lot"]

--- a/bb8/Cargo.toml
+++ b/bb8/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/djc/bb8"
 edition = "2021"
 workspace = ".."
 readme = "../README.md"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [dependencies]
 async-trait = "0.1"

--- a/bb8/src/internals.rs
+++ b/bb8/src/internals.rs
@@ -2,8 +2,8 @@ use std::cmp::min;
 use std::sync::Arc;
 use std::time::Instant;
 
+use crate::lock::Mutex;
 use futures_channel::oneshot;
-use parking_lot::Mutex;
 
 use crate::api::{Builder, ManageConnection};
 use std::collections::VecDeque;

--- a/postgres/Cargo.toml
+++ b/postgres/Cargo.toml
@@ -5,7 +5,7 @@ description = "Full-featured async (tokio-based) postgres connection pool (like 
 license = "MIT"
 repository = "https://github.com/djc/bb8"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.60"
 
 [features]
 "with-bit-vec-0_6" = ["tokio-postgres/with-bit-vec-0_6"]

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -5,7 +5,7 @@ description = "Full-featured async (tokio-based) redis connection pool (like r2d
 license = "MIT"
 repository = "https://github.com/djc/bb8"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.60"
 
 [dependencies]
 async-trait = "0.1"


### PR DESCRIPTION
Rust 1.62 improved `std::sync::Mutex` speed and 1.63 `const`ified its constructor. It can now be used in the same contexts `parking_lot`'s implementation can. 

Currently, `bb8` is enabling the `parking_lot` tokio feature for its users. A library should probably not do that without a good reason. With the recent-ish improvements to `std::sync::Mutex`, I believe we can drop `parking_lot` from the dependency tree entirely.