### PR TITLE
Add LIFO option for getting pool resources

### DIFF
--- a/bb8/src/api.rs
+++ b/bb8/src/api.rs
@@ -102,9 +102,8 @@ pub struct Builder<M: ManageConnection> {
     _p: PhantomData<M>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub enum QueueStrategy {
-    #[default]
     /// First in first out
     /// This strategy behaves like a queue
     /// It will evenly spread load on all existing connections, resetting their idle timeouts, maintaining the pool size
@@ -113,6 +112,12 @@ pub enum QueueStrategy {
     /// This behaves like a stack
     /// It will use the most recently used connection and help to keep the total pool size small by evicting idle connections
     Lifo,
+}
+
+impl Default for QueueStrategy {
+    fn default() -> Self {
+        QueueStrategy::Fifo
+    }
 }
 
 impl<M: ManageConnection> Default for Builder<M> {

--- a/bb8/src/api.rs
+++ b/bb8/src/api.rs
@@ -77,9 +77,9 @@ impl<M: ManageConnection> Pool<M> {
 #[derive(Debug)]
 pub enum QueueStrategy {
     /// Last in first out
-    LIFO,
+    Lifo,
     /// First in first out
-    FIFO,
+    Fifo,
 }
 
 /// A builder for a connection pool.
@@ -122,7 +122,7 @@ impl<M: ManageConnection> Default for Builder<M> {
             retry_connection: true,
             error_sink: Box::new(NopErrorSink),
             reaper_rate: Duration::from_secs(30),
-            queue_strategy: QueueStrategy::FIFO,
+            queue_strategy: QueueStrategy::Fifo,
             connection_customizer: None,
             _p: PhantomData,
         }
@@ -273,7 +273,7 @@ impl<M: ManageConnection> Builder<M> {
 
     /// Sets the queue strategy to be used by the pool
     ///
-    /// Defaults to `FIFO`.
+    /// Defaults to `Fifo`.
     #[must_use]
     pub fn queue_strategy(mut self, queue_strategy: QueueStrategy) -> Self {
         self.queue_strategy = queue_strategy;

--- a/bb8/src/api.rs
+++ b/bb8/src/api.rs
@@ -273,7 +273,7 @@ impl<M: ManageConnection> Builder<M> {
 
     /// Sets the queue strategy to be used by the pool
     ///
-    /// Defaults to `LIFO`.
+    /// Defaults to `FIFO`.
     #[must_use]
     pub fn queue_strategy(mut self, queue_strategy: QueueStrategy) -> Self {
         self.queue_strategy = queue_strategy;

--- a/bb8/src/internals.rs
+++ b/bb8/src/internals.rs
@@ -81,13 +81,10 @@ where
         }
 
         // Queue it in the idle queue
+        let conn = IdleConn::from(guard.conn.take().unwrap());
         match self.queue_strategy {
-            QueueStrategy::FIFO => self
-                .conns
-                .push_back(IdleConn::from(guard.conn.take().unwrap())),
-            QueueStrategy::LIFO => self
-                .conns
-                .push_front(IdleConn::from(guard.conn.take().unwrap())),
+            QueueStrategy::Fifo => self.conns.push_back(conn),
+            QueueStrategy::Lifo => self.conns.push_front(conn),
         }
     }
 
@@ -170,7 +167,7 @@ where
             conns: VecDeque::new(),
             num_conns: 0,
             pending_conns: 0,
-            queue_strategy: QueueStrategy::LIFO,
+            queue_strategy: QueueStrategy::Lifo,
         }
     }
 }

--- a/bb8/src/internals.rs
+++ b/bb8/src/internals.rs
@@ -2,7 +2,7 @@ use std::cmp::min;
 use std::sync::Arc;
 use std::time::Instant;
 
-use crate::{lock::Mutex, api::QueueStrategy};
+use crate::{api::QueueStrategy, lock::Mutex};
 use futures_channel::oneshot;
 
 use crate::api::{Builder, ManageConnection};


### PR DESCRIPTION
The current strategy that bb8 uses for pulling from the connection queue is FIFO. This means that we are constantly resetting idle timers for connections. This PR adds an option to make the queue a stack so that the pool can reuse the most recently used resources and allow older ones to idle timeout.