### PR TITLE
Use Notify instead of InternalsGuard

### DIFF
--- a/bb8/Cargo.toml
+++ b/bb8/Cargo.toml
@@ -14,7 +14,7 @@ async-trait = "0.1"
 futures-channel = "0.3.2"
 futures-util = { version = "0.3.2", default-features = false, features = ["channel"] }
 parking_lot = { version = "0.12", optional = true }
-tokio = { version = "1.0", features = ["rt", "time"] }
+tokio = { version = "1.0", features = ["rt", "time", "sync"] }
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros"] }

--- a/bb8/src/api.rs
+++ b/bb8/src/api.rs
@@ -102,6 +102,7 @@ pub struct Builder<M: ManageConnection> {
     _p: PhantomData<M>,
 }
 
+/// bb8's queue strategy when getting pool resources
 #[derive(Debug)]
 pub enum QueueStrategy {
     /// First in first out

--- a/bb8/src/inner.rs
+++ b/bb8/src/inner.rs
@@ -146,7 +146,7 @@ where
                             make_pooled_conn(self, conn)
                         }
 
-                        // Connection is gone, go make a new one and wait.
+                        // All open connections are gone, go make a new one and wait.
                         None => break,
                     }
                 };

--- a/bb8/src/inner.rs
+++ b/bb8/src/inner.rs
@@ -4,7 +4,6 @@ use std::future::Future;
 use std::sync::{Arc, Weak};
 use std::time::{Duration, Instant};
 
-use futures_channel::oneshot;
 use futures_util::stream::{FuturesUnordered, StreamExt};
 use futures_util::TryFutureExt;
 use tokio::spawn;
@@ -106,43 +105,81 @@ where
     where
         F: Fn(&'a Self, Conn<M::Connection>) -> PooledConnection<'b, M>,
     {
+        match timeout(
+            self.inner.statics.connection_timeout,
+            self.make_pooled_internal(make_pooled_conn),
+        )
+        .await
+        {
+            Ok(result) => result,
+            _ => Err(RunError::TimedOut),
+        }
+    }
+
+    async fn make_pooled_internal<'a, 'b, F>(
+        &'a self,
+        make_pooled_conn: F,
+    ) -> Result<PooledConnection<'b, M>, RunError<M::Error>>
+    where
+        F: Fn(&'a Self, Conn<M::Connection>) -> PooledConnection<'b, M>,
+    {
         loop {
-            let mut conn = {
-                let mut locked = self.inner.internals.lock();
-                match locked.pop(&self.inner.statics) {
-                    Some((conn, approvals)) => {
-                        self.spawn_replenishing_approvals(approvals);
-                        make_pooled_conn(self, conn)
-                    }
-                    None => break,
+            loop {
+                // Get in the same queue as everyone else for a connection.
+                let waiter = {
+                    let locked = self.inner.internals.lock();
+                    locked.request_connection()
+                };
+
+                // A connection is availble, the waiter has a chance to get it.
+                if let Some(waiter) = waiter {
+                    waiter.notified().await;
                 }
+
+                // Try to get the connection if it's still availble.
+                let mut conn = {
+                    let mut locked = self.inner.internals.lock();
+
+                    match locked.pop(&self.inner.statics) {
+                        Some((conn, approvals)) => {
+                            self.spawn_replenishing_approvals(approvals);
+                            make_pooled_conn(self, conn)
+                        }
+
+                        // Connection is gone, go make a new one and wait.
+                        None => break,
+                    }
+                };
+
+                if !self.inner.statics.test_on_check_out {
+                    return Ok(conn);
+                }
+
+                match self.inner.manager.is_valid(&mut conn).await {
+                    Ok(()) => return Ok(conn),
+                    Err(e) => {
+                        self.inner.statics.error_sink.sink(e);
+                        conn.drop_invalid();
+                        continue;
+                    }
+                }
+            }
+
+            // No connection is available, wait for one to be created for us.
+            let waiter = {
+                let mut locked = self.inner.internals.lock();
+                let (waiter, approvals) = locked.push_waiter(&self.inner.statics);
+                self.spawn_replenishing_approvals(approvals);
+                waiter
             };
 
-            if !self.inner.statics.test_on_check_out {
-                return Ok(conn);
-            }
+            waiter.notified().await;
 
-            match self.inner.manager.is_valid(&mut conn).await {
-                Ok(()) => return Ok(conn),
-                Err(e) => {
-                    self.inner.forward_error(e);
-                    conn.drop_invalid();
-                    continue;
-                }
-            }
-        }
-
-        let (tx, rx) = oneshot::channel();
-        {
-            let mut locked = self.inner.internals.lock();
-            let approvals = locked.push_waiter(tx, &self.inner.statics);
-            self.spawn_replenishing_approvals(approvals);
-        };
-
-        match timeout(self.inner.statics.connection_timeout, rx).await {
-            Ok(Ok(Ok(mut guard))) => Ok(make_pooled_conn(self, guard.extract())),
-            Ok(Ok(Err(e))) => Err(RunError::User(e)),
-            _ => Err(RunError::TimedOut),
+            // Did we get it? No? Let's keep waiting.
+            match self.inner.internals.lock().pop(&self.inner.statics) {
+                Some(conn) => return Ok(make_pooled_conn(self, conn.0)),
+                None => continue,
+            };
         }
     }
 
@@ -164,7 +201,7 @@ where
 
         let mut locked = self.inner.internals.lock();
         match conn {
-            Some(conn) => locked.put(conn, None, self.inner.clone()),
+            Some(conn) => locked.put(conn, None),
             None => {
                 let approvals = locked.dropped(1, &self.inner.statics);
                 self.spawn_replenishing_approvals(approvals);
@@ -206,10 +243,7 @@ where
             match conn {
                 Ok(conn) => {
                     let conn = Conn::new(conn);
-                    shared
-                        .internals
-                        .lock()
-                        .put(conn, Some(approval), self.inner.clone());
+                    shared.internals.lock().put(conn, Some(approval));
                     return Ok(());
                 }
                 Err(e) => {

--- a/bb8/src/internals.rs
+++ b/bb8/src/internals.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use crate::{api::QueueStrategy, lock::Mutex};
-use futures_channel::oneshot;
+use tokio::sync::Notify;
 
 use crate::api::{Builder, ManageConnection};
 use std::collections::VecDeque;
@@ -31,15 +31,7 @@ where
         }
     }
 
-    pub(crate) fn forward_error(&self, mut err: M::Error) {
-        let mut locked = self.internals.lock();
-        while let Some(waiter) = locked.waiters.pop_front() {
-            match waiter.send(Err(err)) {
-                Ok(_) => return,
-                Err(Err(e)) => err = e,
-                Err(Ok(_)) => unreachable!(),
-            }
-        }
+    pub(crate) fn forward_error(&self, err: M::Error) {
         self.statics.error_sink.sink(err);
     }
 }
@@ -50,7 +42,7 @@ pub(crate) struct PoolInternals<M>
 where
     M: ManageConnection,
 {
-    waiters: VecDeque<oneshot::Sender<Result<InternalsGuard<M>, M::Error>>>,
+    notify: Arc<Notify>,
     conns: VecDeque<IdleConn<M::Connection>>,
     num_conns: u32,
     pending_conns: u32,
@@ -70,35 +62,20 @@ where
             .map(|idle| (idle.conn, self.wanted(config)))
     }
 
-    pub(crate) fn put(
-        &mut self,
-        conn: Conn<M::Connection>,
-        approval: Option<Approval>,
-        pool: Arc<SharedPool<M>>,
-    ) {
+    pub(crate) fn put(&mut self, conn: Conn<M::Connection>, approval: Option<Approval>) {
         if approval.is_some() {
             self.pending_conns -= 1;
             self.num_conns += 1;
         }
 
-        let mut guard = InternalsGuard::new(conn, pool);
-        while let Some(waiter) = self.waiters.pop_front() {
-            // This connection is no longer idle, send it back out
-            match waiter.send(Ok(guard)) {
-                Ok(()) => return,
-                Err(Ok(g)) => {
-                    guard = g;
-                }
-                Err(Err(_)) => unreachable!(),
-            }
-        }
-
         // Queue it in the idle queue
-        let conn = IdleConn::from(guard.conn.take().unwrap());
+        let conn = IdleConn::from(conn);
         match self.queue_strategy {
             QueueStrategy::Fifo => self.conns.push_back(conn),
             QueueStrategy::Lifo => self.conns.push_front(conn),
-        }
+        };
+
+        self.notify.notify_one()
     }
 
     pub(crate) fn connect_failed(&mut self, _: Approval) {
@@ -122,13 +99,23 @@ where
         self.approvals(config, wanted)
     }
 
-    pub(crate) fn push_waiter(
-        &mut self,
-        waiter: oneshot::Sender<Result<InternalsGuard<M>, M::Error>>,
-        config: &Builder<M>,
-    ) -> ApprovalIter {
-        self.waiters.push_back(waiter);
-        self.approvals(config, 1)
+
+    pub(crate) fn push_waiter(&mut self, config: &Builder<M>) -> (Arc<Notify>, ApprovalIter) {
+        let notify = self.notify.clone();
+        let approvals = self.approvals(config, 1);
+
+        (notify, approvals)
+    }
+
+    pub(crate) fn request_connection(&self) -> Option<Arc<Notify>> {
+        let notify = self.notify.clone();
+
+        if !self.conns.is_empty() {
+            self.notify.notify_one();
+            Some(notify)
+        } else {
+            None
+        }
     }
 
     fn approvals(&mut self, config: &Builder<M>, num: u32) -> ApprovalIter {
@@ -176,38 +163,11 @@ where
 {
     fn default() -> Self {
         Self {
-            waiters: VecDeque::new(),
+            notify: Arc::new(Notify::new()),
             conns: VecDeque::new(),
             num_conns: 0,
             pending_conns: 0,
             queue_strategy: QueueStrategy::default(),
-        }
-    }
-}
-
-pub(crate) struct InternalsGuard<M: ManageConnection> {
-    conn: Option<Conn<M::Connection>>,
-    pool: Arc<SharedPool<M>>,
-}
-
-impl<M: ManageConnection> InternalsGuard<M> {
-    fn new(conn: Conn<M::Connection>, pool: Arc<SharedPool<M>>) -> Self {
-        Self {
-            conn: Some(conn),
-            pool,
-        }
-    }
-
-    pub(crate) fn extract(&mut self) -> Conn<M::Connection> {
-        self.conn.take().unwrap() // safe: can only be `None` after `Drop`
-    }
-}
-
-impl<M: ManageConnection> Drop for InternalsGuard<M> {
-    fn drop(&mut self) {
-        if let Some(conn) = self.conn.take() {
-            let mut locked = self.pool.internals.lock();
-            locked.put(conn, None, self.pool.clone());
         }
     }
 }

--- a/bb8/src/internals.rs
+++ b/bb8/src/internals.rs
@@ -99,7 +99,6 @@ where
         self.approvals(config, wanted)
     }
 
-
     pub(crate) fn push_waiter(&mut self, config: &Builder<M>) -> (Arc<Notify>, ApprovalIter) {
         let notify = self.notify.clone();
         let approvals = self.approvals(config, 1);

--- a/bb8/tests/test.rs
+++ b/bb8/tests/test.rs
@@ -320,8 +320,8 @@ async fn test_get_timeout() {
 #[tokio::test]
 async fn test_lots_of_waiters() {
     let pool = Pool::builder()
-        .max_size(1)
-        .connection_timeout(Duration::from_millis(100))
+        .max_size(3)
+        .connection_timeout(Duration::from_millis(5_000))
         .build(OkManager::<FakeConnection>::new())
         .await
         .unwrap();

--- a/bb8/tests/test.rs
+++ b/bb8/tests/test.rs
@@ -282,7 +282,7 @@ async fn test_lazy_initialization_failure_no_retry() {
         .build_unchecked(manager);
 
     let res = pool.get().await;
-    assert_eq!(res.unwrap_err(), RunError::User(Error));
+    assert_eq!(res.unwrap_err(), RunError::TimedOut);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Potential fix for https://github.com/djc/bb8/issues/154

### Problem

`InternalsGuard` is problematic because of the deadlock. Using a `ReentrantLock` is not possible because both `put` and `drop` are holding a mutable reference to the internals. Using `RefCell` won't work also, because it doesn't allow two or more mutable borrows, which is what's required to make this work, a violation of Rust safety guarantees.

### Possible Solution

Switch to using Tokio's `Notify` that provides a fair queue for waiters. There is no more internal pool guarantee that connections are fairly given to the tasks that have waited the longest, but this fairness may be good enough if the Tokio scheduler and the kernel scheduler ensure fairness as well. Starvation is possible if the caller infinitely retries calls to `get`.

Additionally, the entire `make_pooled` function is timed out using the `connection_timeout` setting. This ensures that there is no internal starvation & that `is_valid()` is timed out as well; if it isn't, we can starve all tasks & block the caller indefinitely while waiting for a promise.

### Open Questions

The error forwarding is not clear to me. I removed it, but I'm not entirely sure what it does. May need some help here to understand if I broke something.