### PR TITLE
Remove dependency on `futures-channel` in favour of `tokio` primitives

### DIFF
--- a/bb8/Cargo.toml
+++ b/bb8/Cargo.toml
@@ -11,8 +11,7 @@ readme = "../README.md"
 
 [dependencies]
 async-trait = "0.1"
-futures-channel = "0.3.2"
-futures-util = { version = "0.3.2", default-features = false, features = ["channel"] }
+futures-util = { version = "0.3.2", default-features = false, features = ["alloc"] }
 parking_lot = { version = "0.12", optional = true }
 tokio = { version = "1.0", features = ["rt", "sync", "time"] }
 

--- a/bb8/tests/test.rs
+++ b/bb8/tests/test.rs
@@ -13,7 +13,7 @@ use std::{error, fmt};
 use async_trait::async_trait;
 use futures_util::future::{err, lazy, ok, pending, ready, try_join_all, FutureExt};
 use futures_util::stream::{FuturesUnordered, TryStreamExt};
-use tokio::{time::timeout, sync::oneshot};
+use tokio::{sync::oneshot, time::timeout};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Error;

--- a/bb8/tests/test.rs
+++ b/bb8/tests/test.rs
@@ -11,10 +11,9 @@ use std::time::Duration;
 use std::{error, fmt};
 
 use async_trait::async_trait;
-use futures_channel::oneshot;
 use futures_util::future::{err, lazy, ok, pending, ready, try_join_all, FutureExt};
 use futures_util::stream::{FuturesUnordered, TryStreamExt};
-use tokio::time::timeout;
+use tokio::{time::timeout, sync::oneshot};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Error;


### PR DESCRIPTION
Since `bb8` is already depending on Tokio, it doesn't really make sense for it to pull in `futures-channel`.  
Especially since this dependency was only used for tests.