### PR TITLE
Provide statistics for get operations

### DIFF
--- a/bb8/src/api.rs
+++ b/bb8/src/api.rs
@@ -85,6 +85,20 @@ pub struct State {
     pub connections: u32,
     /// The number of idle connections.
     pub idle_connections: u32,
+    /// Statistics about the historical usage of the pool.
+    pub statistics: Statistics,
+}
+
+/// Statistics about the historical usage of the `Pool`.
+#[derive(Debug, Default)]
+#[non_exhaustive]
+pub struct Statistics {
+    /// Total gets performed that did not have to wait for a connection.
+    pub get_direct: u64,
+    /// Total gets performed that had to wait for a connection available.
+    pub get_waited: u64,
+    /// Total gets performed that timed out while waiting for a connection.
+    pub get_timed_out: u64,
 }
 
 /// A builder for a connection pool.


### PR DESCRIPTION
# Exposing three new attributes as part of a new `Statistics` type
We will be exposing the three new attributes as part of a new `Statistics` type:

- **get_direct**: Total number of `get` operations performed for retrieving a new connection that did no wait for getting a connection.
- **get_waited**: Total number of `get` operations that had to wait for having a connection available.
- **get_timed_out**: Total number of `get` operations that did time out while waiting for a connection.

See following section for understanding how these two values can be used

# Why adding these three new attributes ?

Tuning the connection pool, specifically the max size and the min idle, its something that needs to be done by gathering data that helps you to understand how well configure are for example these to configuration parameters, which should lead to an ideal situation where the contention of the pool is affordable.

By having visibility of the gets that managed to retrieve a connection without waiting and having too the visibility of the ones that had to wait, the user would have available enough data for understanding if the pool is having contention.

## When contention can happen

There are multiple scenarios where contention at connection pool level can happen, which can be described as the scenario where there are no enough connections free in the pool and the calls for getting a connection need to wait

- When the max size of the pool was underestimated, and the operations for getting a new connection need to constantly wait for having a connection free.
- When the max idle connection is too low, and the operations for getting a new connection have multiple chances to have to pay the cost of creating a new connection.

By adding the `get_direct`, `get_waited` and `get_timed_out` we provide a way to know deterministically  how much contention the connection pool is suffering. By using a simple operation like `(get_waited+get_timed_out)/(get_direct + get_waited+get_timed_out)` the user can understand the percentage of operations that suffered from connection pooling contention.

A low number - i.e < 1% - might indicate that the two variables are properly configured, while bigger numbers - i.e > 5% - might indicate that there is a none negligible amount of operations that are suffering an extra latency due to some level of contention when getting a connection.

# How and when to use it?

There is an expectation that the `State` will be polled every X times, and the user will take the responsibility of calculating the delta from the previous values, something like:

```rust
let state_before = pool.statistics()
let state_after = pool.statistics()

println!("Gets performed within period X: {}", (state_after.get_direct + state_after.get_waited + state_after.get_timed_out) - (state_before.get_direct + state_after.get_waited + state_after.get_timed_out))
println!("Gets performed within period X that wait for a connection: {}", state_after.get_waited - state_before.get_waited)
println!("Gets performed within period X that wait for a connection and timed out: {}", state_after.get_timed_out - state_before.get_timed_out)
```

Deltas can be then sent to your favourite time series database/service - i.e prometheus, DD, etc. 