### PR TITLE
Adds new statistics for tracking connections created and closed

### DIFF
--- a/bb8/src/api.rs
+++ b/bb8/src/api.rs
@@ -100,7 +100,7 @@ pub struct Statistics {
     /// Total gets performed that timed out while waiting for a connection.
     pub get_timed_out: u64,
     /// Total time accumulated waiting for a connection.
-    pub get_waited_time_micro: u64,
+    pub get_waited_time: Duration,
     /// Total connections created.
     pub connections_created: u64,
     /// Total connections that were closed due to be in broken state.

--- a/bb8/src/api.rs
+++ b/bb8/src/api.rs
@@ -99,6 +99,20 @@ pub struct Statistics {
     pub get_waited: u64,
     /// Total gets performed that timed out while waiting for a connection.
     pub get_timed_out: u64,
+    /// Total time accumulated waiting for a connection.
+    pub get_waited_time_micro: u64,
+    /// Total connections created.
+    pub connections_created: u64,
+    /// Total connections that were closed due to be in broken state.
+    pub connections_broken_closed: u64,
+    /// Total connections that were closed due to be considered invalid.
+    pub connections_invalid_closed: u64,
+    /// Total connections that were closed because they reached the max
+    /// lifetime.
+    pub connections_max_lifetime_closed: u64,
+    /// Total connections that were closed because they reached the max
+    /// idle timeout.
+    pub connections_max_idle_timeout_closed: u64,
 }
 
 /// A builder for a connection pool.

--- a/bb8/tests/test.rs
+++ b/bb8/tests/test.rs
@@ -994,7 +994,7 @@ async fn test_state_get_contention() {
     let statistics = pool.state().statistics;
     assert_eq!(statistics.get_direct, 1);
     assert_eq!(statistics.get_waited, 1);
-    assert!(statistics.get_waited_time_micro > 0);
+    assert!(statistics.get_waited_time > Duration::from_micros(0));
 }
 
 #[tokio::test]


### PR DESCRIPTION
We add several new statistics fields for tracking the following:

- `connections_created`: How many connections have been created
- `connections_broken_closed`: How many connections were closed due to a broken state
- `connections_invalid_closed`: How many connections were closed due to be considered invalid.
- `connections_max_lifetime_closed`: How many connections were closed due to reaching the max lifetime.
- `connections_max_idle_timeout_closed`: How many connections were closed due to reaching the idle timeout.

We have added also a new statistic called `get_waited_time_micro` which provides the accumulated time in micros that all calls to the `get` method had to wait for a new connection.