### PR TITLE
Add new statistics for knowing when and why connections were closed

### DIFF
--- a/bb8/src/api.rs
+++ b/bb8/src/api.rs
@@ -101,6 +101,16 @@ pub struct Statistics {
     pub get_timed_out: u64,
     /// Total time accumulated waiting for a connection.
     pub get_wait_time: Duration,
+    /// Total connections that were closed due to be in broken state.
+    pub connections_closed_broken: u64,
+    /// Total connections that were closed due to be considered invalid.
+    pub connections_closed_invalid: u64,
+    /// Total connections that were closed because they reached the max
+    /// lifetime.
+    pub connections_closed_max_lifetime: u64,
+    /// Total connections that were closed because they reached the max
+    /// idle timeout.
+    pub connections_closed_idle_timeout: u64,
 }
 
 /// A builder for a connection pool.


### PR DESCRIPTION
We add 4 new statistics which will be used by the users for knowing when the connections were closed and what was the reason, the new four statistics are:

- `connections_closed_broken`: Total connections that were closed due to be in broken state.
- `connections_closed_invalid`: Total connections that were closed due to be considered invalid.
- `connections_closed_max_lifetime`: Total connections that were closed because they reached the max lifetime.
- `connections_closed_idle_timeout`: Total connections that were closed because they reached the idle timeout.