### PR TITLE
Adds new statistics attributes for tracking connections closed

### DIFF
--- a/bb8/src/api.rs
+++ b/bb8/src/api.rs
@@ -101,6 +101,10 @@ pub struct Statistics {
     pub get_timed_out: u64,
     /// Total time accumulated waiting for a connection.
     pub get_wait_time: Duration,
+    /// Total connections that were closed due to be in broken state.
+    pub connections_closed_broken: u64,
+    /// Total connections that were closed due to be considered invalid.
+    pub connections_closed_invalid: u64,
 }
 
 /// A builder for a connection pool.

--- a/bb8/src/internals.rs
+++ b/bb8/src/internals.rs
@@ -259,11 +259,11 @@ pub(crate) struct AtomicStatistics {
 }
 
 impl AtomicStatistics {
-    pub(crate) fn record_get(&self, kind: StatsKind, wait_time_start: Option<Instant>) {
+    pub(crate) fn record_get(&self, kind: StatsGetKind, wait_time_start: Option<Instant>) {
         match kind {
-            StatsKind::Direct => self.get_direct.fetch_add(1, Ordering::SeqCst),
-            StatsKind::Waited => self.get_waited.fetch_add(1, Ordering::SeqCst),
-            StatsKind::TimedOut => self.get_timed_out.fetch_add(1, Ordering::SeqCst),
+            StatsGetKind::Direct => self.get_direct.fetch_add(1, Ordering::SeqCst),
+            StatsGetKind::Waited => self.get_waited.fetch_add(1, Ordering::SeqCst),
+            StatsGetKind::TimedOut => self.get_timed_out.fetch_add(1, Ordering::SeqCst),
         };
 
         if let Some(wait_time_start) = wait_time_start {
@@ -285,7 +285,7 @@ impl From<&AtomicStatistics> for Statistics {
     }
 }
 
-pub(crate) enum StatsKind {
+pub(crate) enum StatsGetKind {
     Direct,
     Waited,
     TimedOut,

--- a/bb8/tests/test.rs
+++ b/bb8/tests/test.rs
@@ -246,6 +246,7 @@ async fn test_drop_on_broken() {
     }
 
     assert!(DROPPED.load(Ordering::SeqCst));
+    assert_eq!(pool.state().statistics.connections_closed_broken, 1);
 }
 
 #[tokio::test]
@@ -453,6 +454,9 @@ async fn test_now_invalid() {
     // Now try to get a new connection.
     let r = pool.get().await;
     assert!(r.is_err());
+
+    // both connections in the pool were considered invalid
+    assert_eq!(pool.state().statistics.connections_closed_invalid, 2);
 }
 
 #[tokio::test]


### PR DESCRIPTION
The two new attributes `connections_closed_broken` and `connections_closed_invalid` can be used for respectively understand how many connections were closed due to be considered broken or invalid.

The `StatsKind` internal enum was also renamed to `StatsGetKind` for better clarity.

Note: A new PR for tracking the reaped connections will be created on top of these changes.