### PR TITLE
Adds new connections_created statistic

### DIFF
--- a/bb8/src/api.rs
+++ b/bb8/src/api.rs
@@ -101,6 +101,8 @@ pub struct Statistics {
     pub get_timed_out: u64,
     /// Total time accumulated waiting for a connection.
     pub get_wait_time: Duration,
+    /// Total connections created.
+    pub connections_created: u64,
     /// Total connections that were closed due to be in broken state.
     pub connections_closed_broken: u64,
     /// Total connections that were closed due to be considered invalid.

--- a/bb8/src/inner.rs
+++ b/bb8/src/inner.rs
@@ -196,6 +196,7 @@ where
                         .internals
                         .lock()
                         .put(conn, Some(approval), self.inner.clone());
+                    self.inner.statistics.record(StatsKind::Created);
                     return Ok(());
                 }
                 Err(e) => {

--- a/bb8/src/internals.rs
+++ b/bb8/src/internals.rs
@@ -272,6 +272,7 @@ pub(crate) struct AtomicStatistics {
     pub(crate) get_waited: AtomicU64,
     pub(crate) get_timed_out: AtomicU64,
     pub(crate) get_wait_time_micros: AtomicU64,
+    pub(crate) connections_created: AtomicU64,
     pub(crate) connections_closed_broken: AtomicU64,
     pub(crate) connections_closed_invalid: AtomicU64,
     pub(crate) connections_closed_max_lifetime: AtomicU64,
@@ -295,6 +296,7 @@ impl AtomicStatistics {
 
     pub(crate) fn record(&self, kind: StatsKind) {
         match kind {
+            StatsKind::Created => &self.connections_created,
             StatsKind::ClosedBroken => &self.connections_closed_broken,
             StatsKind::ClosedInvalid => &self.connections_closed_invalid,
         }
@@ -320,6 +322,7 @@ impl From<&AtomicStatistics> for Statistics {
             get_waited: item.get_waited.load(Ordering::SeqCst),
             get_timed_out: item.get_timed_out.load(Ordering::SeqCst),
             get_wait_time: Duration::from_micros(item.get_wait_time_micros.load(Ordering::SeqCst)),
+            connections_created: item.connections_created.load(Ordering::SeqCst),
             connections_closed_broken: item.connections_closed_broken.load(Ordering::SeqCst),
             connections_closed_invalid: item.connections_closed_invalid.load(Ordering::SeqCst),
             connections_closed_max_lifetime: item
@@ -339,6 +342,7 @@ pub(crate) enum StatsGetKind {
 }
 
 pub(crate) enum StatsKind {
+    Created,
     ClosedBroken,
     ClosedInvalid,
 }


### PR DESCRIPTION
With the new `connections_created` statistic users can know how many connections have been created by the pool.

This one is the latest PR in the series of PRs that are adding sufficient statistics to the pool that are required for monitoring and debugging systems in production.