### PR TITLE
Bump 0.8.5 version

### DIFF
--- a/bb8/Cargo.toml
+++ b/bb8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bb8"
-version = "0.8.4"
+version = "0.8.5"
 edition = "2021"
 rust-version = "1.63"
 description = "Full-featured async (tokio-based) connection pool (like r2d2)"

--- a/bb8/src/lib.rs
+++ b/bb8/src/lib.rs
@@ -36,7 +36,7 @@
 mod api;
 pub use api::{
     Builder, CustomizeConnection, ErrorSink, ManageConnection, NopErrorSink, Pool,
-    PooledConnection, QueueStrategy, RunError, State,
+    PooledConnection, QueueStrategy, RunError, State, Statistics,
 };
 
 mod inner;


### PR DESCRIPTION
Just fixes and issue with the docs which makes available the `Statistics` struct.

Better now

<img width="1125" alt="Screenshot 2024-06-14 at 15 26 25" src="https://github.com/user-attachments/assets/517b675b-96f7-48d7-bb07-8bc6247d7e10">
