### PR TITLE
Add `Pool::add`

### DIFF
--- a/bb8/src/lib.rs
+++ b/bb8/src/lib.rs
@@ -35,7 +35,7 @@
 
 mod api;
 pub use api::{
-    Builder, CustomizeConnection, ErrorSink, ManageConnection, NopErrorSink, Pool,
+    AddError, Builder, CustomizeConnection, ErrorSink, ManageConnection, NopErrorSink, Pool,
     PooledConnection, QueueStrategy, RunError, State, Statistics,
 };
 

--- a/bb8/tests/test.rs
+++ b/bb8/tests/test.rs
@@ -208,14 +208,9 @@ fn test_is_send_sync() {
 }
 
 // A connection manager that always returns `true` for `has_broken()`
+#[derive(Default)]
 struct BrokenConnectionManager<C> {
     _c: PhantomData<C>,
-}
-
-impl<C> BrokenConnectionManager<C> {
-    fn new() -> Self {
-        BrokenConnectionManager { _c: PhantomData }
-    }
 }
 
 #[async_trait]
@@ -250,7 +245,7 @@ async fn test_drop_on_broken() {
     }
 
     let pool = Pool::builder()
-        .build(BrokenConnectionManager::<Connection>::new())
+        .build(BrokenConnectionManager::<Connection>::default())
         .await
         .unwrap();
 

--- a/bb8/tests/test.rs
+++ b/bb8/tests/test.rs
@@ -1020,3 +1020,51 @@ async fn test_statistics_connections_created() {
 
     assert_eq!(pool.state().statistics.connections_created, 1);
 }
+
+#[tokio::test]
+async fn test_can_use_added_connections() {
+    let pool = Pool::builder()
+        .connection_timeout(Duration::from_millis(1))
+        .build_unchecked(NthConnectionFailManager::<FakeConnection>::new(0));
+
+    // Assert pool can't replenish connections on its own
+    let res = pool.get().await;
+    assert_eq!(res.unwrap_err(), RunError::TimedOut);
+
+    pool.add(FakeConnection).unwrap();
+    let res = pool.get().await;
+    assert!(res.is_ok());
+}
+
+#[tokio::test]
+async fn test_add_ok_until_max_size() {
+    let pool = Pool::builder()
+        .min_idle(1)
+        .max_size(3)
+        .build(OkManager::<FakeConnection>::new())
+        .await
+        .unwrap();
+
+    for _ in 0..2 {
+        let conn = pool.dedicated_connection().await.unwrap();
+        pool.add(conn).unwrap();
+    }
+
+    let conn = pool.dedicated_connection().await.unwrap();
+    let res = pool.add(conn);
+    assert!(matches!(res, Err(AddError::NoCapacity(_))));
+}
+
+#[tokio::test]
+async fn test_add_checks_broken_connections() {
+    let pool = Pool::builder()
+        .min_idle(1)
+        .max_size(3)
+        .build(BrokenConnectionManager::<FakeConnection>::default())
+        .await
+        .unwrap();
+
+    let conn = pool.dedicated_connection().await.unwrap();
+    let res = pool.add(conn);
+    assert!(matches!(res, Err(AddError::Broken(_))));
+}


### PR DESCRIPTION
Fixes #212

This adds `Pool::add`, which allows for externally created connections to be added and managed by the pool. If the pool is at maximum capacity when this method is called, it will return the input connection as part of the Err response.

I considered allowing `Pool:add` to ignore `max_size` when adding to the pool, but felt it could lead to confusion if the pool is allowed to exceed its capacity in this specific case.

This change required making PoolInternals::approvals visible within the crate to get the approval needed to add a new connection. The alternative would have required defining a new pub(crate) method for this specific use case, which feels worse. I'm open to suggestions on how to more cleanly integrate this change into the package.
