### PR TITLE
testcontainers instead of manual docker run

### DIFF
--- a/postgres/Cargo.toml
+++ b/postgres/Cargo.toml
@@ -26,4 +26,5 @@ tokio-postgres = "0.7"
 
 [dev-dependencies]
 futures-util = "0.3.2"
+testcontainers-modules = { version = "0.9", features = ["postgres"] }
 tokio = { version = "1.0.0", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
What do you think if I make it for all examples?

Main benefit: e.g. for postgres port can be anything and will be managed by testcontainers while use can refer it like default `5432`

```rust
    let db_port = postgres_container.get_host_port_ipv4(5432).await.unwrap();
```