### PR TITLE
Fix leaky connections

### DIFF
--- a/bb8/src/inner.rs
+++ b/bb8/src/inner.rs
@@ -91,6 +91,7 @@ where
         let mut wait_time_start = None;
 
         let future = async {
+            let _guard = self.inner.request();
             loop {
                 let (conn, approvals) = self.inner.pop();
                 self.spawn_replenishing_approvals(approvals);

--- a/bb8/tests/test.rs
+++ b/bb8/tests/test.rs
@@ -1068,3 +1068,37 @@ async fn test_add_checks_broken_connections() {
     let res = pool.add(conn);
     assert!(matches!(res, Err(AddError::Broken(_))));
 }
+
+#[tokio::test]
+async fn test_reuse_on_drop() {
+    let pool = Pool::builder()
+        .min_idle(0)
+        .max_size(100)
+        .queue_strategy(QueueStrategy::Lifo)
+        .build(OkManager::<FakeConnection>::new())
+        .await
+        .unwrap();
+
+    // The first get should
+    // 1) see nothing in the pool,
+    // 2) spawn a single replenishing approval,
+    // 3) get notified of the new connection and grab it from the pool
+    let conn_0 = pool.get().await.expect("should connect");
+    // Dropping the connection queues up a notify
+    drop(conn_0);
+    // The second get should
+    // 1) see the first connection in the pool and grab it
+    let _conn_1: PooledConnection<OkManager<FakeConnection>> =
+        pool.get().await.expect("should connect");
+    // The third get will
+    // 1) see nothing in the pool,
+    // 2) spawn a single replenishing approval,
+    // 3) get notified of the new connection,
+    // 4) see nothing in the pool,
+    // 5) _not_ spawn a single replenishing approval,
+    // 6) get notified of the new connection and grab it from the pool
+    let _conn_2: PooledConnection<OkManager<FakeConnection>> =
+        pool.get().await.expect("should connect");
+
+    assert_eq!(pool.state().connections, 2);
+}


### PR DESCRIPTION
Fixes #221

It's possible to trigger more approvals than are necessary, in turn
grabbing more connections than we need. This happens when we drop a
connection. The drop produces a notify, which doesn't get used until the
pool is empty. The first `Pool::get()` call on an empty pool will spawn
an connect task, immediately complete `notify.notified().await`, then
spawn a second connect task. Both will connect and we'll end up with 1
more connection than we need.

Rather than address the notify issue directly, this fix introduces some
bookkeeping that tracks the number of open `pool.get()` requests we have
waiting on connections. If the number of pending connections >= the
number of pending gets, we will not spawn any additional connect tasks.

~~I have additionally changed `notify.notify_waiters();` to a
`notify.notify_one();` call in the broken connection branch. A single
broken connection should only need to notify one pending task to spawn a
new connect task, not all of them.~~ See https://github.com/djc/bb8/pull/225
