### PR TITLE
Change notify_waiters to notify_one on broken conns

### DIFF
--- a/bb8/src/inner.rs
+++ b/bb8/src/inner.rs
@@ -158,7 +158,7 @@ where
                 }
                 let approvals = locked.dropped(1, &self.inner.statics);
                 self.spawn_replenishing_approvals(approvals);
-                self.inner.notify.notify_waiters();
+                self.inner.notify.notify_one();
             }
         }
     }


### PR DESCRIPTION
When a connection is dropped but broken, we notify all waiting get requests that they should try again. This is done in order to ensure we have enough pending connections to serve all in- flight gets. Because only a single connection dropped however, we only need to notify one waiter to refresh, not all of them.

I'm moving this from https://github.com/djc/bb8/pull/223 just to prove it doesn't break any tests.