### PR TITLE
Replace async_trait with native async fns

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.70.0
+          toolchain: 1.75.0
       - run: cargo test -p bb8
 
   lint:

--- a/bb8/Cargo.toml
+++ b/bb8/Cargo.toml
@@ -10,7 +10,6 @@ workspace = ".."
 readme = "../README.md"
 
 [dependencies]
-async-trait = "0.1"
 futures-util = { version = "0.3.2", default-features = false, features = ["alloc"] }
 parking_lot = { version = "0.12", optional = true }
 tokio = { version = "1.0", features = ["rt", "sync", "time"] }

--- a/bb8/Cargo.toml
+++ b/bb8/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bb8"
 version = "0.8.6"
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.75"
 description = "Full-featured async (tokio-based) connection pool (like r2d2)"
 license = "MIT"
 repository = "https://github.com/djc/bb8"

--- a/bb8/Cargo.toml
+++ b/bb8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bb8"
-version = "0.8.6"
+version = "0.9.0"
 edition = "2021"
 rust-version = "1.75"
 description = "Full-featured async (tokio-based) connection pool (like r2d2)"

--- a/postgres/Cargo.toml
+++ b/postgres/Cargo.toml
@@ -19,7 +19,6 @@ repository = "https://github.com/djc/bb8"
 "with-time-0_3" = ["tokio-postgres/with-time-0_3"]
 
 [dependencies]
-async-trait = "0.1"
 bb8 = { version = "0.8", path = "../bb8" }
 tokio = { version = "1.0.0", features = ["rt"] }
 tokio-postgres = "0.7"

--- a/postgres/Cargo.toml
+++ b/postgres/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bb8-postgres"
 version = "0.8.1"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.75"
 description = "Full-featured async (tokio-based) postgres connection pool (like r2d2)"
 license = "MIT"
 repository = "https://github.com/djc/bb8"

--- a/postgres/Cargo.toml
+++ b/postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bb8-postgres"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2021"
 rust-version = "1.75"
 description = "Full-featured async (tokio-based) postgres connection pool (like r2d2)"
@@ -19,7 +19,7 @@ repository = "https://github.com/djc/bb8"
 "with-time-0_3" = ["tokio-postgres/with-time-0_3"]
 
 [dependencies]
-bb8 = { version = "0.8", path = "../bb8" }
+bb8 = { version = "0.9", path = "../bb8" }
 tokio = { version = "1.0.0", features = ["rt"] }
 tokio-postgres = "0.7"
 

--- a/postgres/src/lib.rs
+++ b/postgres/src/lib.rs
@@ -4,7 +4,6 @@
 pub use bb8;
 pub use tokio_postgres;
 
-use async_trait::async_trait;
 use tokio_postgres::config::Config;
 use tokio_postgres::tls::{MakeTlsConnect, TlsConnect};
 use tokio_postgres::{Client, Error, Socket};
@@ -45,7 +44,6 @@ where
     }
 }
 
-#[async_trait]
 impl<Tls> bb8::ManageConnection for PostgresConnectionManager<Tls>
 where
     Tls: MakeTlsConnect<Socket> + Clone + Send + Sync + 'static,

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bb8-redis"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 rust-version = "1.75"
 description = "Full-featured async (tokio-based) redis connection pool (like r2d2)"
@@ -8,7 +8,7 @@ license = "MIT"
 repository = "https://github.com/djc/bb8"
 
 [dependencies]
-bb8 = { version = "0.8", path = "../bb8" }
+bb8 = { version = "0.9", path = "../bb8" }
 redis = { version = "0.27", default-features = false, features = ["tokio-comp"] }
 
 [dev-dependencies]

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bb8-redis"
 version = "0.17.0"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.75"
 description = "Full-featured async (tokio-based) redis connection pool (like r2d2)"
 license = "MIT"
 repository = "https://github.com/djc/bb8"

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -8,7 +8,6 @@ license = "MIT"
 repository = "https://github.com/djc/bb8"
 
 [dependencies]
-async-trait = "0.1"
 bb8 = { version = "0.8", path = "../bb8" }
 redis = { version = "0.27", default-features = false, features = ["tokio-comp"] }
 

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -38,7 +38,6 @@
 pub use bb8;
 pub use redis;
 
-use async_trait::async_trait;
 use redis::{aio::MultiplexedConnection, ErrorKind};
 use redis::{Client, IntoConnectionInfo, RedisError};
 
@@ -58,7 +57,6 @@ impl RedisConnectionManager {
     }
 }
 
-#[async_trait]
 impl bb8::ManageConnection for RedisConnectionManager {
     type Connection = MultiplexedConnection;
     type Error = RedisError;


### PR DESCRIPTION
Note that the usage of `CustomizeConnection` requires it to be object safe, and thus we need to use boxed futures instead of plain async fns.