### PR TITLE
Use portable-atomic when AtomicU64 is not available.

### DIFF
--- a/bb8/Cargo.toml
+++ b/bb8/Cargo.toml
@@ -14,6 +14,9 @@ futures-util = { version = "0.3.2", default-features = false, features = ["alloc
 parking_lot = { version = "0.12", optional = true }
 tokio = { version = "1.0", features = ["rt", "sync", "time"] }
 
+[target.'cfg(not(target_has_atomic = "u64"))'.dependencies]
+portable-atomic = "1"
+
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros"] }
 

--- a/bb8/src/internals.rs
+++ b/bb8/src/internals.rs
@@ -1,6 +1,10 @@
+#[cfg(not(target_has_atomic = "64"))]
+use portable_atomic::AtomicU64;
 use std::cmp::min;
 use std::collections::VecDeque;
-use std::sync::atomic::{AtomicU64, Ordering};
+#[cfg(target_has_atomic = "64")]
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 

--- a/bb8/src/internals.rs
+++ b/bb8/src/internals.rs
@@ -1,5 +1,3 @@
-#[cfg(not(target_has_atomic = "64"))]
-use portable_atomic::AtomicU64;
 use std::cmp::min;
 use std::collections::VecDeque;
 #[cfg(target_has_atomic = "64")]
@@ -8,6 +6,8 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+#[cfg(not(target_has_atomic = "64"))]
+use portable_atomic::AtomicU64;
 use tokio::sync::Notify;
 
 use crate::api::{Builder, ManageConnection, QueueStrategy, State, Statistics};


### PR DESCRIPTION
*edit* Only fixes #232 if applied to a 0.8.x branch.

AtomicU64 was introduced in v0.8.4
The current version is 0.9.0, please update 0.8.x too.
